### PR TITLE
Upload the releaser distributions as artifacts

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -53,3 +53,8 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlite-xeus-lua-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist


### PR DESCRIPTION
Add a step to upload the distributions built by the Jupyter Releaser on CI.

This is useful for example for testing the generated wheel for a given PR.