### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,40 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/first-commit...47d189ec2368f191401605bdbb1217353cbd635f))
+
+### Enhancements made
+
+- using kernel agnostic names [#23](https://github.com/jupyterlite/xeus-lua-kernel/pull/23) ([@DerThorsten](https://github.com/DerThorsten))
+- Fix handling of kernelspec logos [#20](https://github.com/jupyterlite/xeus-lua-kernel/pull/20) ([@jtpio](https://github.com/jtpio))
+- Size [#17](https://github.com/jupyterlite/xeus-lua-kernel/pull/17) ([@DerThorsten](https://github.com/DerThorsten))
+- No more shared-array-buffer [#14](https://github.com/jupyterlite/xeus-lua-kernel/pull/14) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Bugs fixed
+
+- Fix Check Release job on CI [#12](https://github.com/jupyterlite/xeus-lua-kernel/pull/12) ([@jtpio](https://github.com/jtpio))
+- copy wasm file via plugin [#10](https://github.com/jupyterlite/xeus-lua-kernel/pull/10) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Maintenance and upkeep improvements
+
+- Update package name and cleanup [#26](https://github.com/jupyterlite/xeus-lua-kernel/pull/26) ([@jtpio](https://github.com/jtpio))
+- Update links after the move to the org [#25](https://github.com/jupyterlite/xeus-lua-kernel/pull/25) ([@jtpio](https://github.com/jtpio))
+- pinning the repos in the Dockerfile [#22](https://github.com/jupyterlite/xeus-lua-kernel/pull/22) ([@DerThorsten](https://github.com/DerThorsten))
+- More cleanup [#21](https://github.com/jupyterlite/xeus-lua-kernel/pull/21) ([@jtpio](https://github.com/jtpio))
+- Cleanup webpack.config.js [#19](https://github.com/jupyterlite/xeus-lua-kernel/pull/19) ([@jtpio](https://github.com/jtpio))
+- Upload the releaser distributions as artifacts [#18](https://github.com/jupyterlite/xeus-lua-kernel/pull/18) ([@jtpio](https://github.com/jtpio))
+- minor fixes [#15](https://github.com/jupyterlite/xeus-lua-kernel/pull/15) ([@DerThorsten](https://github.com/DerThorsten))
+- Remove unused files [#13](https://github.com/jupyterlite/xeus-lua-kernel/pull/13) ([@jtpio](https://github.com/jtpio))
+- Build the extension [#6](https://github.com/jupyterlite/xeus-lua-kernel/pull/6) ([@jtpio](https://github.com/jtpio))
+- Troubleshoot build issues [#3](https://github.com/jupyterlite/xeus-lua-kernel/pull/3) ([@jtpio](https://github.com/jtpio))
+- added webpack config [#2](https://github.com/jupyterlite/xeus-lua-kernel/pull/2) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2021-10-04&to=2021-10-22&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2021-10-04..2021-10-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3Ajtpio+updated%3A2021-10-04..2021-10-22&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-lua-kernel  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | first-commit |