### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/v0.1.1...af5f8dae02a71dce1f0664b081bfba8366106c0c))
+
+### Enhancements made
+
+- Binary buffers [#30](https://github.com/jupyterlite/xeus-lua-kernel/pull/30) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2021-10-22&to=2021-11-16&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2021-10-22..2021-11-16&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.1
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/first-commit...47d189ec2368f191401605bdbb1217353cbd635f))
@@ -37,5 +53,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2021-10-04&to=2021-10-22&type=c))
 
 [@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2021-10-04..2021-10-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3Ajtpio+updated%3A2021-10-04..2021-10-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-lua-kernel  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.1 |