### PR TITLE
Automated Changelog Entry for 0.3.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.0
+
+([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/v0.2.0...57b43c598768a3c2e5edf4cd5cb35a56c677ed8c))
+
+### Enhancements made
+
+- No JS callback [#34](https://github.com/jupyterlite/xeus-lua-kernel/pull/34) ([@SylvainCorlay](https://github.com/SylvainCorlay))
+
+### Other merged PRs
+
+- updated to 0.6.3 / fixes xwidgets layout error [#35](https://github.com/jupyterlite/xeus-lua-kernel/pull/35) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2021-11-18&to=2022-03-17&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2021-11-18..2022-03-17&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ASylvainCorlay+updated%3A2021-11-18..2022-03-17&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.0
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/v0.1.1...af5f8dae02a71dce1f0664b081bfba8366106c0c))
@@ -15,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2021-10-22&to=2021-11-16&type=c))
 
 [@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2021-10-22..2021-11-16&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-lua-kernel  |
| Branch  | main  |
| Version Spec | 0.3.0 |
| Since | v0.2.0 |