### PR TITLE
Automated Changelog Entry for 0.3.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.3.2
+
+([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/v0.3.1...5125c4d14e40d99884f268760bec156d2a279547))
+
+### Merged PRs
+
+- update xeus [#39](https://github.com/jupyterlite/xeus-lua-kernel/pull/39) ([@DerThorsten](https://github.com/DerThorsten))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2022-04-12&to=2022-05-19&type=c))
+
+[@DerThorsten](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3ADerThorsten+updated%3A2022-04-12..2022-05-19&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.3.1
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-lua-kernel/compare/v0.3.0...c3e9eb7a7eca22e95640db22534751905c79002b))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-lua-kernel/graphs/contributors?from=2022-03-18&to=2022-04-12&type=c))
 
 [@martinRenou](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-lua-kernel+involves%3AmartinRenou+updated%3A2022-03-18..2022-04-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.3.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-lua-kernel  |
| Branch  | main  |
| Version Spec | 0.3.2 |
| Since Last Stable | true |