### PR TITLE
Update the plugin id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import logo32 from '../style/logos/lua-logo-32x32.png';
 import logo64 from '../style/logos/lua-logo-64x64.png';
 
 const server_kernel: JupyterLiteServerPlugin<void> = {
-  id: '@jupyterlite/xeus-kernel-extension:kernel',
+  id: '@jupyterlite/xeus-lua-kernel-extension:kernel',
   autoStart: true,
   requires: [IKernelSpecs],
   activate: (app: JupyterLiteServer, kernelspecs: IKernelSpecs) => {


### PR DESCRIPTION
Similar to https://github.com/jupyterlite/xeus-python-kernel/pull/43

To avoid collisions with the same plugin ids on plugin activation.